### PR TITLE
feat(release): crates.io first publish flow and merge changelog automation

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -199,7 +199,7 @@ PY
         id: changelog
         run: |
           VERSION="${{ needs.detect.outputs.version }}"
-          PREV_TAG=$(git tag -l 'v*' --sort=-v:refname | head -1)
+          PREV_TAG=$(git tag -l 'v*' --sort=-v:refname | awk -v current="v${VERSION}" '$0 != current { print; exit }')
 
           {
             echo "## What's Changed"
@@ -210,7 +210,7 @@ PY
             echo ""
             echo "\`\`\`bash"
             echo "cargo install rusty-stack --locked"
-            echo "rusty-stack"
+            echo "rusty"
             echo "\`\`\`"
             echo ""
             echo "The PyPI package is a compatibility wrapper that installs the same crates.io binary."
@@ -218,7 +218,7 @@ PY
             echo "Rusty Llama remains installed only through Rusty Stack:"
             echo ""
             echo "\`\`\`bash"
-            echo "rusty-stack update llama-cpp"
+            echo "rusty update llama-cpp"
             echo "\`\`\`"
             echo ""
             echo "**Windows support is in ALPHA testing. We are openly accepting testers! The easiest way to become a tester is to test on your system/hardware, and when issues are encountered, open an issue following the issue template.**"

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -204,6 +204,23 @@ PY
           {
             echo "## What's Changed"
             echo ""
+            echo "## Install"
+            echo ""
+            echo "Rusty Stack is now published as the \`rusty\` crates.io package:"
+            echo ""
+            echo "\`\`\`bash"
+            echo "cargo install rusty --locked"
+            echo "rusty"
+            echo "\`\`\`"
+            echo ""
+            echo "The PyPI package is a compatibility wrapper that installs the same crates.io binary."
+            echo ""
+            echo "Rusty Llama remains installed only through Rusty Stack:"
+            echo ""
+            echo "\`\`\`bash"
+            echo "rusty update llama-cpp"
+            echo "\`\`\`"
+            echo ""
             echo "**Windows support is in ALPHA testing. We are openly accepting testers! The easiest way to become a tester is to test on your system/hardware, and when issues are encountered, open an issue following the issue template.**"
             echo ""
 
@@ -261,10 +278,10 @@ PY
         run: |
           VERSION=$(grep '^version =' Cargo.toml | head -1 | sed 's/.*"\(.*\)".*/\1/')
           # Skip if this version already exists on crates.io (idempotent for retries)
-          if cargo search rusty-stack 2>/dev/null | grep -q "^rusty-stack = \"${VERSION}\""; then
+          if cargo search rusty 2>/dev/null | grep -q "^rusty = \"${VERSION}\""; then
             echo "Version ${VERSION} already published to crates.io — skipping"
           else
-            cargo publish --allow-dirty
+            cargo publish --locked
           fi
         env:
           CARGO_REGISTRY_TOKEN: ${{ secrets.CARGO_REGISTRY_TOKEN }}
@@ -357,8 +374,8 @@ PY
           echo "| PyPI | ${{ needs.pypi.result }} |" >> "$GITHUB_STEP_SUMMARY"
           echo "" >> "$GITHUB_STEP_SUMMARY"
           echo "### Registry notes" >> "$GITHUB_STEP_SUMMARY"
-          echo "- **crates.io**: Publishes the Rust crate (required)" >> "$GITHUB_STEP_SUMMARY"
-          echo "- **PyPI**: Thin Python wrapper that installs via cargo (OIDC trusted publishing)" >> "$GITHUB_STEP_SUMMARY"
+          echo "- **crates.io**: Publishes \`rusty\`; users install with \`cargo install rusty --locked\` (required)" >> "$GITHUB_STEP_SUMMARY"
+          echo "- **PyPI**: Thin Python wrapper that installs the \`rusty\` crates.io binary (OIDC trusted publishing)" >> "$GITHUB_STEP_SUMMARY"
           echo "" >> "$GITHUB_STEP_SUMMARY"
           echo "### Windows ALPHA" >> "$GITHUB_STEP_SUMMARY"
           echo "**Windows support is in ALPHA testing. We are openly accepting testers! The easiest way to become a tester is to test on your system/hardware, and when issues are encountered, open an issue following the issue template.**" >> "$GITHUB_STEP_SUMMARY"

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -206,11 +206,11 @@ PY
             echo ""
             echo "## Install"
             echo ""
-            echo "Rusty Stack is now published as the \`rusty\` crates.io package:"
+            echo "Rusty Stack is now published as the \`rusty-stack\` crates.io package:"
             echo ""
             echo "\`\`\`bash"
-            echo "cargo install rusty --locked"
-            echo "rusty"
+            echo "cargo install rusty-stack --locked"
+            echo "rusty-stack"
             echo "\`\`\`"
             echo ""
             echo "The PyPI package is a compatibility wrapper that installs the same crates.io binary."
@@ -218,7 +218,7 @@ PY
             echo "Rusty Llama remains installed only through Rusty Stack:"
             echo ""
             echo "\`\`\`bash"
-            echo "rusty update llama-cpp"
+            echo "rusty-stack update llama-cpp"
             echo "\`\`\`"
             echo ""
             echo "**Windows support is in ALPHA testing. We are openly accepting testers! The easiest way to become a tester is to test on your system/hardware, and when issues are encountered, open an issue following the issue template.**"
@@ -278,7 +278,7 @@ PY
         run: |
           VERSION=$(grep '^version =' Cargo.toml | head -1 | sed 's/.*"\(.*\)".*/\1/')
           # Skip if this version already exists on crates.io (idempotent for retries)
-          if cargo search rusty 2>/dev/null | grep -q "^rusty = \"${VERSION}\""; then
+          if cargo search rusty-stack 2>/dev/null | grep -q "^rusty-stack = \"${VERSION}\""; then
             echo "Version ${VERSION} already published to crates.io — skipping"
           else
             cargo publish --locked
@@ -374,8 +374,8 @@ PY
           echo "| PyPI | ${{ needs.pypi.result }} |" >> "$GITHUB_STEP_SUMMARY"
           echo "" >> "$GITHUB_STEP_SUMMARY"
           echo "### Registry notes" >> "$GITHUB_STEP_SUMMARY"
-          echo "- **crates.io**: Publishes \`rusty\`; users install with \`cargo install rusty --locked\` (required)" >> "$GITHUB_STEP_SUMMARY"
-          echo "- **PyPI**: Thin Python wrapper that installs the \`rusty\` crates.io binary (OIDC trusted publishing)" >> "$GITHUB_STEP_SUMMARY"
+          echo "- **crates.io**: Publishes \`rusty-stack\`; users install with \`cargo install rusty-stack --locked\` (required)" >> "$GITHUB_STEP_SUMMARY"
+          echo "- **PyPI**: Thin Python wrapper that installs the \`rusty-stack\` crates.io binary (OIDC trusted publishing)" >> "$GITHUB_STEP_SUMMARY"
           echo "" >> "$GITHUB_STEP_SUMMARY"
           echo "### Windows ALPHA" >> "$GITHUB_STEP_SUMMARY"
           echo "**Windows support is in ALPHA testing. We are openly accepting testers! The easiest way to become a tester is to test on your system/hardware, and when issues are encountered, open an issue following the issue template.**" >> "$GITHUB_STEP_SUMMARY"

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -278,7 +278,8 @@ PY
         run: |
           VERSION=$(grep '^version =' Cargo.toml | head -1 | sed 's/.*"\(.*\)".*/\1/')
           # Skip if this version already exists on crates.io (idempotent for retries)
-          if cargo search rusty-stack 2>/dev/null | grep -q "^rusty-stack = \"${VERSION}\""; then
+          PUBLISHED=$(curl -sSf "https://crates.io/api/v1/crates/rusty-stack" 2>/dev/null | python3 -c "import sys,json; d=json.load(sys.stdin); print(d.get('crate',{}).get('max_stable_version',''))" 2>/dev/null || echo "")
+          if [ "$PUBLISHED" = "$VERSION" ]; then
             echo "Version ${VERSION} already published to crates.io — skipping"
           else
             cargo publish --locked

--- a/.github/workflows/update-changelog-on-merge.yml
+++ b/.github/workflows/update-changelog-on-merge.yml
@@ -20,15 +20,18 @@ jobs:
       - uses: actions/checkout@v4
         with:
           fetch-depth: 0
+          ref: main
+          persist-credentials: true
 
       - name: Generate appended changelog entry
         id: changelog
+        env:
+          PR_TITLE: ${{ github.event.pull_request.title }}
+          PR_NUMBER: ${{ github.event.pull_request.number }}
+          PR_URL: ${{ github.event.pull_request.html_url }}
+          AUTHOR: ${{ github.event.pull_request.user.login }}
         run: |
           set -euo pipefail
-          PR_TITLE="${{ github.event.pull_request.title }}"
-          PR_NUMBER="${{ github.event.pull_request.number }}"
-          PR_URL="${{ github.event.pull_request.html_url }}"
-          AUTHOR="${{ github.event.pull_request.user.login }}"
           DATE=$(date +%Y-%m-%d)
 
           ENTRY="$DATE - [$PR_TITLE]($PR_URL) (@$AUTHOR)"
@@ -56,4 +59,12 @@ jobs:
           git config user.email "github-actions[bot]@users.noreply.github.com"
           git add CHANGELOG.md
           git commit -m "chore(release): append changelog for PR #${{ github.event.pull_request.number }}"
-          git push origin HEAD:main
+
+      - name: Push with retry
+        if: steps.changelog.outputs.updated == 'true'
+        run: |
+          for i in 1 2 3; do
+            git pull --rebase origin main && git push origin HEAD:main && break
+            echo "Push failed, retrying in $((i * 5))s..."
+            sleep $((i * 5))
+          done

--- a/.github/workflows/update-changelog-on-merge.yml
+++ b/.github/workflows/update-changelog-on-merge.yml
@@ -1,0 +1,59 @@
+name: Update Changelog on Merge
+
+on:
+  pull_request:
+    types: [closed]
+
+permissions:
+  contents: write
+  pull-requests: write
+
+concurrency:
+  group: changelog-${{ github.ref }}
+  cancel-in-progress: true
+
+jobs:
+  changelog:
+    if: ${{ github.event.pull_request.merged == true && github.event.pull_request.base.ref == 'main' }}
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
+
+      - name: Generate appended changelog entry
+        id: changelog
+        run: |
+          set -euo pipefail
+          PR_TITLE="${{ github.event.pull_request.title }}"
+          PR_NUMBER="${{ github.event.pull_request.number }}"
+          PR_URL="${{ github.event.pull_request.html_url }}"
+          AUTHOR="${{ github.event.pull_request.user.login }}"
+          DATE=$(date +%Y-%m-%d)
+
+          ENTRY="$DATE - [$PR_TITLE]($PR_URL) (@$AUTHOR)"
+
+          if ! grep -qF "$PR_URL" CHANGELOG.md; then
+            if grep -q '^## \[Unreleased\]' CHANGELOG.md; then
+              tmp=$(mktemp)
+              awk -v entry="$ENTRY" '
+                /^## \[Unreleased\]/ { print; print ""; print entry; next }
+                { print }
+              ' CHANGELOG.md > "$tmp" && mv "$tmp" CHANGELOG.md
+            else
+              printf '\n## [Unreleased]\n\n%s\n' "$ENTRY" >> CHANGELOG.md
+            fi
+            echo "updated=true" >> "$GITHUB_OUTPUT"
+            echo "entry=$ENTRY" >> "$GITHUB_OUTPUT"
+          else
+            echo "updated=false" >> "$GITHUB_OUTPUT"
+          fi
+
+      - name: Commit changelog update
+        if: steps.changelog.outputs.updated == 'true'
+        run: |
+          git config user.name "github-actions[bot]"
+          git config user.email "github-actions[bot]@users.noreply.github.com"
+          git add CHANGELOG.md
+          git commit -m "chore(release): append changelog for PR #${{ github.event.pull_request.number }}"
+          git push origin HEAD:main

--- a/.github/workflows/update-changelog-on-merge.yml
+++ b/.github/workflows/update-changelog-on-merge.yml
@@ -9,15 +9,15 @@ permissions:
   pull-requests: write
 
 concurrency:
-  group: changelog-${{ github.ref }}
-  cancel-in-progress: true
+  group: changelog-main
+  cancel-in-progress: false
 
 jobs:
   changelog:
     if: ${{ github.event.pull_request.merged == true && github.event.pull_request.base.ref == 'main' }}
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683
         with:
           fetch-depth: 0
           ref: main
@@ -34,7 +34,8 @@ jobs:
           set -euo pipefail
           DATE=$(date +%Y-%m-%d)
 
-          ENTRY="$DATE - [$PR_TITLE]($PR_URL) (@$AUTHOR)"
+          SANITIZED_TITLE="$(printf '%s' "$PR_TITLE" | tr -d '\n\r[]')"
+          ENTRY="$DATE - $SANITIZED_TITLE (@$AUTHOR) — $PR_URL"
 
           if ! grep -qF "$PR_URL" CHANGELOG.md; then
             if grep -q '^## \[Unreleased\]' CHANGELOG.md; then
@@ -63,8 +64,14 @@ jobs:
       - name: Push with retry
         if: steps.changelog.outputs.updated == 'true'
         run: |
+          set -euo pipefail
+          pushed=false
           for i in 1 2 3; do
-            git pull --rebase origin main && git push origin HEAD:main && break
+            git pull --rebase origin main && git push origin HEAD:main && { pushed=true; break; }
             echo "Push failed, retrying in $((i * 5))s..."
             sleep $((i * 5))
           done
+          if [ "$pushed" = false ]; then
+            echo "::error::Failed to push changelog update after 3 attempts"
+            exit 1
+          fi

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,7 @@ All notable changes to Stan's ML Stack will be documented in this file.
 ## [0.2.0] - 2026-05-30 — Anagami
 
 ### Added
+- **crates.io first release path**: Rusty Stack now publishes as the `rusty` crate so users can install the CLI/TUI with `cargo install rusty --locked`; GitHub release notes and PyPI wrapper flow point to that crate as the canonical binary source.
 - **All-Rust installer milestone**: All 35 installer, verification, and benchmark components are routed through native Rust modules; selectable components in `state.rs` no longer reference shell scripts.
 - **Rusty Llama CUDA isolation guards**: llama.cpp installs now force `GGML_HIP=ON`, `GGML_CUDA=OFF`, `GGML_VULKAN=OFF`, and `GGML_METAL=OFF`; source builds validate `CMakeCache.txt`; source and prebuilt installs reject binaries without ROCm/HIP linkage.
 - **Rusty Llama CUDA toolkit warning**: The installer warns when `nvcc`, `nvidia-smi`, or `/usr/local/cuda` are present while continuing with HIP-only builds for mixed-GPU systems.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,7 +10,7 @@ All notable changes to Stan's ML Stack will be documented in this file.
 ## [0.2.0] - 2026-05-30 — Anagami
 
 ### Added
-- **crates.io first release path**: Rusty Stack now publishes as the `rusty` crate so users can install the CLI/TUI with `cargo install rusty --locked`; GitHub release notes and PyPI wrapper flow point to that crate as the canonical binary source.
+- **crates.io first release path**: Rusty Stack now publishes as the `rusty-stack` crate so users can install the CLI/TUI with `cargo install rusty-stack --locked`; GitHub release notes and PyPI wrapper flow point to that crate as the canonical binary source.
 - **All-Rust installer milestone**: All 35 installer, verification, and benchmark components are routed through native Rust modules; selectable components in `state.rs` no longer reference shell scripts.
 - **Rusty Llama CUDA isolation guards**: llama.cpp installs now force `GGML_HIP=ON`, `GGML_CUDA=OFF`, `GGML_VULKAN=OFF`, and `GGML_METAL=OFF`; source builds validate `CMakeCache.txt`; source and prebuilt installs reject binaries without ROCm/HIP linkage.
 - **Rusty Llama CUDA toolkit warning**: The installer warns when `nvcc`, `nvidia-smi`, or `/usr/local/cuda` are present while continuing with HIP-only builds for mixed-GPU systems.

--- a/MIGRATION.md
+++ b/MIGRATION.md
@@ -348,17 +348,17 @@ python3 scripts/install_ml_stack_ui.py
 
 ```bash
 # Install from crates.io
-cargo install rusty --locked
+cargo install rusty-stack --locked
 
 # Run the TUI installer
-rusty
+rusty-stack
 
 # Or use individual subcommands
-rusty update --scan-only     # Check for updates
-rusty update --all-safe      # Apply safe updates
-rusty verify --full          # Verify installation
-rusty bench --list           # List benchmarks
-rusty bench --all            # Run all benchmarks
+rusty-stack update --scan-only     # Check for updates
+rusty-stack update --all-safe      # Apply safe updates
+rusty-stack verify --full          # Verify installation
+rusty-stack bench --list           # List benchmarks
+rusty-stack bench --all            # Run all benchmarks
 ```
 
 ### Source Build
@@ -377,7 +377,7 @@ cargo build --release
 | Requirement | Before | After |
 |---|---|---|
 | Python | 3.10-3.13 | 3.10-3.13 (unchanged) |
-| Rust | Not required | Current stable Rust, via rustup, for `cargo install rusty` or source builds |
+| Rust | Not required | Current stable Rust, via rustup, for `cargo install rusty-stack` or source builds |
 | Shell | bash | bash (for remaining active scripts) |
 | Package manager | apt/dnf/pacman | apt/dnf/pacman (unchanged) |
 

--- a/MIGRATION.md
+++ b/MIGRATION.md
@@ -350,15 +350,15 @@ python3 scripts/install_ml_stack_ui.py
 # Install from crates.io
 cargo install rusty-stack --locked
 
-# Run the TUI installer
-rusty-stack
+# Launch the interactive TUI installer
+rusty
 
 # Or use individual subcommands
-rusty-stack update --scan-only     # Check for updates
-rusty-stack update --all-safe      # Apply safe updates
-rusty-stack verify --full          # Verify installation
-rusty-stack bench --list           # List benchmarks
-rusty-stack bench --all            # Run all benchmarks
+rusty update --scan-only     # Check for updates
+rusty update --all-safe      # Apply safe updates
+rusty verify --full          # Verify installation
+rusty bench --list           # List benchmarks
+rusty bench --all            # Run all benchmarks
 ```
 
 ### Source Build

--- a/MIGRATION.md
+++ b/MIGRATION.md
@@ -347,33 +347,29 @@ python3 scripts/install_ml_stack_ui.py
 ### After: Rusty Stack Installation
 
 ```bash
-# Clone the repository
-git clone https://github.com/scooter-lacroix/Stan-s-ML-Stack.git
-cd Stan-s-ML-Stack/rusty-stack
+# Install from crates.io
+cargo install rusty --locked
 
-# Build from source
-cargo build --release
-
-# Run the TUI installer (same as rusty-stack binary)
-./target/release/rusty
+# Run the TUI installer
+rusty
 
 # Or use individual subcommands
-./target/release/rusty update --scan-only     # Check for updates
-./target/release/rusty update --all-safe      # Apply safe updates
-./target/release/rusty verify --full           # Verify installation
-./target/release/rusty bench --list            # List benchmarks
-./target/release/rusty bench --all             # Run all benchmarks
-
-# Quick install (still available)
-curl -fsSL https://raw.githubusercontent.com/scooter-lacroix/Stan-s-ML-Stack/main/scripts/install.sh | bash
+rusty update --scan-only     # Check for updates
+rusty update --all-safe      # Apply safe updates
+rusty verify --full          # Verify installation
+rusty bench --list           # List benchmarks
+rusty bench --all            # Run all benchmarks
 ```
 
-### One-Line Install
+### Source Build
 
-The curl-based install still works and now builds the Rust binary:
+Build from source only when developing Rusty Stack itself:
 
 ```bash
-curl -fsSL https://raw.githubusercontent.com/scooter-lacroix/Stan-s-ML-Stack/main/scripts/install.sh | bash
+git clone https://github.com/scooter-lacroix/Stan-s-ML-Stack.git
+cd Stan-s-ML-Stack/rusty-stack
+cargo build --release
+./target/release/rusty
 ```
 
 ### Build Requirements
@@ -381,7 +377,7 @@ curl -fsSL https://raw.githubusercontent.com/scooter-lacroix/Stan-s-ML-Stack/mai
 | Requirement | Before | After |
 |---|---|---|
 | Python | 3.10-3.13 | 3.10-3.13 (unchanged) |
-| Rust | Not required | 1.70+ (for building from source) |
+| Rust | Not required | Current stable Rust, via rustup, for `cargo install rusty` or source builds |
 | Shell | bash | bash (for remaining active scripts) |
 | Package manager | apt/dnf/pacman | apt/dnf/pacman (unchanged) |
 

--- a/README.md
+++ b/README.md
@@ -8,7 +8,7 @@
 
 **Rusty Stack** is a comprehensive machine learning environment optimized for AMD GPUs. It provides a complete set of tools and libraries for training and deploying machine learning models, with a focus on large language models (LLMs) and deep learning.
 
-Formerly known as "Stan's ML Stack", this project has been fully migrated to Rusty Stack — a native Rust CLI and TUI installer that replaces the original shell scripts and Python UIs. The Python package (`Rusty-Stack`) is available on PyPI. See [MIGRATION.md](MIGRATION.md) for the complete migration guide.
+Formerly known as "Stan's ML Stack", this project has been fully migrated to Rusty Stack — a native Rust CLI and TUI installer that replaces the original shell scripts and Python UIs. The primary package is published on crates.io as `rusty`, enabling `cargo install rusty`. The Python package (`Rusty-Stack`) remains available on PyPI as a compatibility wrapper. See [MIGRATION.md](MIGRATION.md) for the complete migration guide.
 
 This stack is designed to work with AMD's ROCm platform, providing CUDA compatibility through HIP, allowing you to run most CUDA-based machine learning code on AMD GPUs with minimal modifications.
 
@@ -47,7 +47,7 @@ For a detailed guide to help you get started from the ground up, head over to [B
 Rusty Llama installation is only supported through Rusty Stack. The installer explicitly configures `GGML_HIP=ON`, `GGML_CUDA=OFF`, `GGML_VULKAN=OFF`, and `GGML_METAL=OFF`, validates `CMakeCache.txt`, warns when NVIDIA toolkits are present, and rejects binaries that do not show ROCm/HIP linkage.
 
 Docs: https://github.com/scooter-lacroix/rusty-llama-docs
-Install: `rusty update llama-cpp`
+Install Rusty Stack first with `cargo install rusty --locked`, then install Rusty Llama with `rusty update llama-cpp`.
 
 ## Windows Support (ALPHA)
 
@@ -224,10 +224,11 @@ The ML Stack provides several installation options to suit your needs.
 - ✅ **Flash Attention (Triton)**: Fully supported and optimized for RDNA 3/4
 - 🔄 **Flash Attention CK**: Pre-release testing and debugging in progress
 
-### Quick Install (One-Line)
+### Quick Install (Recommended)
 
 ```bash
-curl -fsSL https://raw.githubusercontent.com/scooter-lacroix/Stan-s-ML-Stack/main/scripts/install.sh | bash
+cargo install rusty --locked
+rusty
 ```
 
 ### Rusty-Stack TUI (Primary Installer)
@@ -235,16 +236,17 @@ curl -fsSL https://raw.githubusercontent.com/scooter-lacroix/Stan-s-ML-Stack/mai
 The recommended way to install Rusty Stack is using the unified `rusty` CLI:
 
 ```bash
-# Build + run Rusty-Stack
-cd rusty-stack
-cargo build --release
-./target/release/rusty
+# Install from crates.io
+cargo install rusty --locked
+
+# Launch the interactive installer
+rusty
 ```
 
 Or use the backward-compatible alias:
 
 ```bash
-./target/release/rusty-stack
+rusty-stack
 ```
 
 This will:
@@ -277,13 +279,14 @@ This export is designed for performance validation, regression comparison, and s
 
 ### PyPI Installation
 
-Install via PyPI (Python package, maintained for backward compatibility):
+Install via PyPI only when you need the backward-compatible Python entrypoints. The PyPI package installs the matching crates.io `rusty` binary through Cargo:
 
 ```bash
 pip install Rusty-Stack
+ml-stack-install
 ```
 
-This will install the core package with all necessary dependencies.
+For direct use, prefer `cargo install rusty --locked`.
 
 ### Legacy Installers (Deprecated)
 

--- a/README.md
+++ b/README.md
@@ -8,7 +8,7 @@
 
 **Rusty Stack** is a comprehensive machine learning environment optimized for AMD GPUs. It provides a complete set of tools and libraries for training and deploying machine learning models, with a focus on large language models (LLMs) and deep learning.
 
-Formerly known as "Stan's ML Stack", this project has been fully migrated to Rusty Stack — a native Rust CLI and TUI installer that replaces the original shell scripts and Python UIs. The primary package is published on crates.io as `rusty-stack`, enabling `cargo install rusty-stack`. The Python package (`Rusty-Stack`) remains available on PyPI as a compatibility wrapper. See [MIGRATION.md](MIGRATION.md) for the complete migration guide.
+Formerly known as "Stan's ML Stack", this project has been fully migrated to Rusty Stack — a native Rust CLI and TUI installer that replaces the original shell scripts and Python UIs. The primary package is published on crates.io as `rusty-stack`, enabling `cargo install rusty-stack --locked`. The Python package (`Rusty-Stack`) remains available on PyPI as a compatibility wrapper. See [MIGRATION.md](MIGRATION.md) for the complete migration guide.
 
 This stack is designed to work with AMD's ROCm platform, providing CUDA compatibility through HIP, allowing you to run most CUDA-based machine learning code on AMD GPUs with minimal modifications.
 

--- a/README.md
+++ b/README.md
@@ -8,7 +8,7 @@
 
 **Rusty Stack** is a comprehensive machine learning environment optimized for AMD GPUs. It provides a complete set of tools and libraries for training and deploying machine learning models, with a focus on large language models (LLMs) and deep learning.
 
-Formerly known as "Stan's ML Stack", this project has been fully migrated to Rusty Stack — a native Rust CLI and TUI installer that replaces the original shell scripts and Python UIs. The primary package is published on crates.io as `rusty`, enabling `cargo install rusty`. The Python package (`Rusty-Stack`) remains available on PyPI as a compatibility wrapper. See [MIGRATION.md](MIGRATION.md) for the complete migration guide.
+Formerly known as "Stan's ML Stack", this project has been fully migrated to Rusty Stack — a native Rust CLI and TUI installer that replaces the original shell scripts and Python UIs. The primary package is published on crates.io as `rusty-stack`, enabling `cargo install rusty-stack`. The Python package (`Rusty-Stack`) remains available on PyPI as a compatibility wrapper. See [MIGRATION.md](MIGRATION.md) for the complete migration guide.
 
 This stack is designed to work with AMD's ROCm platform, providing CUDA compatibility through HIP, allowing you to run most CUDA-based machine learning code on AMD GPUs with minimal modifications.
 
@@ -47,7 +47,7 @@ For a detailed guide to help you get started from the ground up, head over to [B
 Rusty Llama installation is only supported through Rusty Stack. The installer explicitly configures `GGML_HIP=ON`, `GGML_CUDA=OFF`, `GGML_VULKAN=OFF`, and `GGML_METAL=OFF`, validates `CMakeCache.txt`, warns when NVIDIA toolkits are present, and rejects binaries that do not show ROCm/HIP linkage.
 
 Docs: https://github.com/scooter-lacroix/rusty-llama-docs
-Install Rusty Stack first with `cargo install rusty --locked`, then install Rusty Llama with `rusty update llama-cpp`.
+Install Rusty Stack first with `cargo install rusty-stack --locked`, then install Rusty Llama with `rusty update llama-cpp`.
 
 ## Windows Support (ALPHA)
 
@@ -227,26 +227,23 @@ The ML Stack provides several installation options to suit your needs.
 ### Quick Install (Recommended)
 
 ```bash
-cargo install rusty --locked
-rusty
+cargo install rusty-stack --locked
+rusty-stack
 ```
 
 ### Rusty-Stack TUI (Primary Installer)
 
-The recommended way to install Rusty Stack is using the unified `rusty` CLI:
+The recommended way to install Rusty Stack is using the crates.io package:
 
 ```bash
 # Install from crates.io
-cargo install rusty --locked
+cargo install rusty-stack --locked
 
-# Launch the interactive installer
-rusty
-```
-
-Or use the backward-compatible alias:
-
-```bash
+# Launch the interactive TUI installer
 rusty-stack
+
+# Or use the CLI-only binary
+rusty update --scan-only
 ```
 
 This will:
@@ -279,14 +276,14 @@ This export is designed for performance validation, regression comparison, and s
 
 ### PyPI Installation
 
-Install via PyPI only when you need the backward-compatible Python entrypoints. The PyPI package installs the matching crates.io `rusty` binary through Cargo:
+Install via PyPI only when you need the backward-compatible Python entrypoints. The PyPI package installs the matching crates.io `rusty-stack` binary through Cargo:
 
 ```bash
 pip install Rusty-Stack
 ml-stack-install
 ```
 
-For direct use, prefer `cargo install rusty --locked`.
+For direct use, prefer `cargo install rusty-stack --locked`.
 
 ### Legacy Installers (Deprecated)
 

--- a/docs/MIGRATION.md
+++ b/docs/MIGRATION.md
@@ -11,15 +11,15 @@ Rusty Stack (formerly "Stan's ML Stack") is the same AMD GPU-focused machine lea
 | Aspect | Before | After |
 |--------|--------|-------|
 | Project Name | Stan's ML Stack | Rusty Stack |
-| Primary Installer | Python curses UI | `cargo install rusty` + Rusty Stack TUI/CLI |
+| Primary Installer | Python curses UI | `cargo install rusty-stack` + Rusty Stack TUI/CLI |
 | Repository | `scooter-lacroix/Stan-s-ML-Stack` | **Unchanged** (same repository) |
 | Python Package | `stans-ml-stack` | `Rusty-Stack` compatibility wrapper |
-| Rust Package | N/A | `rusty` on crates.io |
+| Rust Package | N/A | `rusty-stack` on crates.io |
 
 ### What's Staying the Same?
 
 - **Repository URL**: `https://github.com/scooter-lacroix/Stan-s-ML-Stack`
-- **Primary Install**: `cargo install rusty --locked`
+- **Primary Install**: `cargo install rusty-stack --locked`
 - **PyPI Package**: `pip install Rusty-Stack` remains as a compatibility wrapper
 - **Backend Scripts**: archived and no longer part of the active install path
 - **Components**: ROCm, PyTorch, vLLM, etc. - same components
@@ -38,8 +38,8 @@ The Python curses installer (`install_ml_stack_curses.py`) is now deprecated.
 
 **New way:**
 ```bash
-cargo install rusty --locked
-rusty
+cargo install rusty-stack --locked
+rusty-stack
 ```
 
 **Good news:** Existing installations remain compatible; new installs should use the Rust CLI/TUI.
@@ -60,8 +60,8 @@ The Go installer (`mlstack-installer/`) is deprecated and no longer maintained.
 
 **Migration:** Switch to Rusty-Stack TUI:
 ```bash
-cargo install rusty --locked
-rusty
+cargo install rusty-stack --locked
+rusty-stack
 ```
 
 ## Component Installation

--- a/docs/MIGRATION.md
+++ b/docs/MIGRATION.md
@@ -11,7 +11,7 @@ Rusty Stack (formerly "Stan's ML Stack") is the same AMD GPU-focused machine lea
 | Aspect | Before | After |
 |--------|--------|-------|
 | Project Name | Stan's ML Stack | Rusty Stack |
-| Primary Installer | Python curses UI | `cargo install rusty-stack` + Rusty Stack TUI/CLI |
+| Primary Installer | Python curses UI | `cargo install rusty-stack --locked` + Rusty Stack TUI/CLI |
 | Repository | `scooter-lacroix/Stan-s-ML-Stack` | **Unchanged** (same repository) |
 | Python Package | `stans-ml-stack` | `Rusty-Stack` compatibility wrapper |
 | Rust Package | N/A | `rusty-stack` on crates.io |

--- a/docs/MIGRATION.md
+++ b/docs/MIGRATION.md
@@ -11,15 +11,17 @@ Rusty Stack (formerly "Stan's ML Stack") is the same AMD GPU-focused machine lea
 | Aspect | Before | After |
 |--------|--------|-------|
 | Project Name | Stan's ML Stack | Rusty Stack |
-| Primary Installer | Python curses UI | Rusty-Stack TUI (Rust + Ratatui) |
+| Primary Installer | Python curses UI | `cargo install rusty` + Rusty Stack TUI/CLI |
 | Repository | `scooter-lacroix/Stan-s-ML-Stack` | **Unchanged** (same repository) |
-| Python Package | `stans-ml-stack` | `Rusty-Stack` (renamed on PyPI) |
+| Python Package | `stans-ml-stack` | `Rusty-Stack` compatibility wrapper |
+| Rust Package | N/A | `rusty` on crates.io |
 
 ### What's Staying the Same?
 
 - **Repository URL**: `https://github.com/scooter-lacroix/Stan-s-ML-Stack`
-- **PyPI Package**: `pip install Rusty-Stack` (renamed from `stans-ml-stack`)
-- **Backend Scripts**: All `scripts/install_*.sh` scripts remain unchanged
+- **Primary Install**: `cargo install rusty --locked`
+- **PyPI Package**: `pip install Rusty-Stack` remains as a compatibility wrapper
+- **Backend Scripts**: archived and no longer part of the active install path
 - **Components**: ROCm, PyTorch, vLLM, etc. - same components
 - **Functionality**: Your ML stack works exactly the same
 
@@ -36,14 +38,11 @@ The Python curses installer (`install_ml_stack_curses.py`) is now deprecated.
 
 **New way:**
 ```bash
-# One-line install
-curl -fsSL https://raw.githubusercontent.com/scooter-lacroix/Stan-s-ML-Stack/main/scripts/install.sh | bash
-
-# Or manual build
-./scripts/run_rusty_stack.sh
+cargo install rusty --locked
+rusty
 ```
 
-**Good news:** Both installers use the same backend shell scripts, so your existing installation is compatible.
+**Good news:** Existing installations remain compatible; new installs should use the Rust CLI/TUI.
 
 ### If You Used the PyPI Package
 
@@ -53,7 +52,7 @@ The PyPI package is maintained for backward compatibility.
 pip install Rusty-Stack  # Renamed from stans-ml-stack
 ```
 
-The package now points to Rusty-Stack TUI as the recommended installer.
+The package now installs the matching crates.io `rusty` binary and exposes compatibility entrypoints.
 
 ### If You Used the Go Installer
 
@@ -61,7 +60,8 @@ The Go installer (`mlstack-installer/`) is deprecated and no longer maintained.
 
 **Migration:** Switch to Rusty-Stack TUI:
 ```bash
-./scripts/run_rusty_stack.sh
+cargo install rusty --locked
+rusty
 ```
 
 ## Component Installation

--- a/docs/index.md
+++ b/docs/index.md
@@ -133,24 +133,20 @@ The ML Stack consists of the following core components:
 
 The ML Stack provides several installation options to suit your needs.
 
-### Quick Install (One-Line)
+### Quick Install (Recommended)
 
 ```bash
-curl -fsSL https://raw.githubusercontent.com/scooter-lacroix/Stan-s-ML-Stack/main/scripts/install.sh | bash
+cargo install rusty --locked
+rusty
 ```
 
 ### Rusty-Stack TUI (Primary Installer)
 
-The recommended way to install Rusty Stack is using the Rust-based **Rusty-Stack** TUI:
+The recommended way to install Rusty Stack is using the crates.io `rusty` package:
 
 ```bash
-# Build + run Rusty-Stack
-./scripts/run_rusty_stack.sh
-
-# Or build manually
-cd rusty-stack
-cargo build --release
-./target/release/rusty-stack
+cargo install rusty --locked
+rusty
 ```
 
 This script will:
@@ -164,10 +160,11 @@ The TUI provides a responsive, interactive experience with real-time feedback du
 
 ### PyPI Installation
 
-Install via PyPI (Python package, maintained for backward compatibility):
+Install via PyPI only for backward-compatible Python entrypoints. The wrapper installs the matching crates.io binary:
 
 ```bash
 pip install Rusty-Stack
+ml-stack-install
 ```
 
 ### Legacy Installers (Deprecated)

--- a/docs/index.md
+++ b/docs/index.md
@@ -136,17 +136,17 @@ The ML Stack provides several installation options to suit your needs.
 ### Quick Install (Recommended)
 
 ```bash
-cargo install rusty --locked
-rusty
+cargo install rusty-stack --locked
+rusty-stack
 ```
 
 ### Rusty-Stack TUI (Primary Installer)
 
-The recommended way to install Rusty Stack is using the crates.io `rusty` package:
+The recommended way to install Rusty Stack is using the crates.io `rusty-stack` package:
 
 ```bash
-cargo install rusty --locked
-rusty
+cargo install rusty-stack --locked
+rusty-stack
 ```
 
 This script will:

--- a/docs/rusty_stack_guide.md
+++ b/docs/rusty_stack_guide.md
@@ -45,35 +45,29 @@ Three ROCm channels are available, selectable via the TUI or `INSTALL_ROCM_PRESE
 | Channel | ROCm Version | Use Case |
 |---------|-------------|----------|
 | **Legacy** | 6.4.3 | Production-proven stability |
-| **Stable** | 7.1 | Production-ready for RDNA 3 |
-| **Latest** | 7.2.1 | Default, expanded RDNA 4 support |
+| **Stable** | 7.2.3 | Production-ready for RDNA 3/4 |
+| **Latest** | 7.2.4 | Default, current ROCm production release |
 
 ---
 
 ## Quick Start
 
 ```bash
-# Clone the repository
-git clone https://github.com/scooter-lacroix/Stan-s-ML-Stack.git
-cd Stan-s-ML-Stack
-
-# Build the Rust CLI
-cd rusty-stack && cargo build --release
-
-# Launch the interactive TUI installer
-./target/release/rusty
+cargo install rusty --locked
+rusty
 
 # Or use CLI subcommands directly
-./target/release/rusty update --scan-only   # Check for updates
-./target/release/rusty verify --full        # Verify installation
-./target/release/rusty bench --all          # Run benchmarks
-./target/release/rusty deps                 # Check Rust dependency updates
+rusty update --scan-only   # Check for updates
+rusty verify --full        # Verify installation
+rusty bench --all          # Run benchmarks
+rusty deps                 # Check Rust dependency updates
 ```
 
 ### One-Line Install
 
 ```bash
-curl -fsSL https://raw.githubusercontent.com/scooter-lacroix/Stan-s-ML-Stack/main/scripts/install.sh | bash
+cargo install rusty --locked
+rusty
 ```
 
 ---

--- a/docs/rusty_stack_guide.md
+++ b/docs/rusty_stack_guide.md
@@ -53,21 +53,21 @@ Three ROCm channels are available, selectable via the TUI or `INSTALL_ROCM_PRESE
 ## Quick Start
 
 ```bash
-cargo install rusty --locked
-rusty
+cargo install rusty-stack --locked
+rusty-stack
 
 # Or use CLI subcommands directly
-rusty update --scan-only   # Check for updates
-rusty verify --full        # Verify installation
-rusty bench --all          # Run benchmarks
-rusty deps                 # Check Rust dependency updates
+rusty-stack update --scan-only   # Check for updates
+rusty-stack verify --full        # Verify installation
+rusty-stack bench --all          # Run benchmarks
+rusty-stack deps                 # Check Rust dependency updates
 ```
 
 ### One-Line Install
 
 ```bash
-cargo install rusty --locked
-rusty
+cargo install rusty-stack --locked
+rusty-stack
 ```
 
 ---

--- a/rusty-stack/Cargo.lock
+++ b/rusty-stack/Cargo.lock
@@ -1934,7 +1934,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b39cdef0fa800fc44525c84ccb54a029961a8215f9619753635a9c0d2538d46d"
 
 [[package]]
-name = "rusty"
+name = "rusty-stack"
 version = "0.2.0"
 dependencies = [
  "anyhow",

--- a/rusty-stack/Cargo.lock
+++ b/rusty-stack/Cargo.lock
@@ -1934,7 +1934,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b39cdef0fa800fc44525c84ccb54a029961a8215f9619753635a9c0d2538d46d"
 
 [[package]]
-name = "rusty-stack"
+name = "rusty"
 version = "0.2.0"
 dependencies = [
  "anyhow",

--- a/rusty-stack/Cargo.toml
+++ b/rusty-stack/Cargo.toml
@@ -1,5 +1,5 @@
 [package]
-name = "rusty"
+name = "rusty-stack"
 version = "0.2.0"
 edition = "2021"
 description = "A comprehensive ML environment installer and platform toolkit optimized for AMD GPUs with ROCm support"

--- a/rusty-stack/Cargo.toml
+++ b/rusty-stack/Cargo.toml
@@ -1,5 +1,5 @@
 [package]
-name = "rusty-stack"
+name = "rusty"
 version = "0.2.0"
 edition = "2021"
 description = "A comprehensive ML environment installer and platform toolkit optimized for AMD GPUs with ROCm support"
@@ -10,12 +10,24 @@ readme = "../README.md"
 keywords = ["rocm", "amd", "gpu", "ml", "installer"]
 categories = ["command-line-utilities", "hardware-support", "science"]
 homepage = "https://github.com/scooter-lacroix/Stan-s-ML-Stack"
+include = [
+    "/Cargo.toml",
+    "/Cargo.lock",
+    "/build.rs",
+    "/README.md",
+    "/src/**",
+    "/tests/**",
+]
 
 [features]
 default = ["tui", "telemetry-submit", "unix-deps"]
 tui = ["crossterm", "ratatui"]
 telemetry-submit = ["reqwest", "tokio"]
 unix-deps = ["libc"]
+
+[lib]
+name = "rusty_stack"
+path = "src/lib.rs"
 
 [[bin]]
 name = "rusty-stack"
@@ -26,10 +38,6 @@ required-features = ["tui", "unix-deps"]
 name = "rusty"
 path = "src/bin/rusty.rs"
 required-features = ["unix-deps"]
-
-[[bin]]
-name = "debug_sort"
-path = "debug_sort.rs"
 
 [dependencies]
 anyhow = "1.0"

--- a/rusty-stack/Cargo.toml
+++ b/rusty-stack/Cargo.toml
@@ -14,7 +14,6 @@ include = [
     "/Cargo.toml",
     "/Cargo.lock",
     "/build.rs",
-    "/README.md",
     "/src/**",
     "/tests/**",
 ]

--- a/rusty-stack/src/bin/rusty.rs
+++ b/rusty-stack/src/bin/rusty.rs
@@ -1199,11 +1199,12 @@ mod upgrade_impl {
                                 );
                             }
                         }
+                        process::exit(1);
                     } else {
                         println!("Current version: v{VERSION}");
                         println!("Schema version: {schema_version}");
                         eprintln!("Unable to check latest release: {error}");
-                        return;
+                        process::exit(1);
                     }
                 }
             }

--- a/rusty-stack/src/bin/rusty.rs
+++ b/rusty-stack/src/bin/rusty.rs
@@ -1124,8 +1124,7 @@ mod upgrade_impl {
     use super::*;
     use rusty_stack::orchestrator::upgrade::{
         self, BinaryDownloader, DownloadResult, ReleaseInfo, ReleaseProvider, SmokeTester,
-        UpgradeError,
-        UpgradeOptions, UpgradeResult, UpgradeStatus, UserInteractor, VersionInfo,
+        UpgradeError, UpgradeOptions, UpgradeResult, UpgradeStatus, UserInteractor, VersionInfo,
     };
 
     pub fn run(
@@ -1204,8 +1203,8 @@ mod upgrade_impl {
                         println!("Current version: v{VERSION}");
                         println!("Schema version: {schema_version}");
                         eprintln!("Unable to check latest release: {error}");
+                        return;
                     }
-                    process::exit(1);
                 }
             }
             return;
@@ -1354,7 +1353,10 @@ mod upgrade_impl {
     struct RealDownloader;
 
     impl BinaryDownloader for RealDownloader {
-        fn download(&self, release: &ReleaseInfo) -> std::result::Result<DownloadResult, UpgradeError> {
+        fn download(
+            &self,
+            release: &ReleaseInfo,
+        ) -> std::result::Result<DownloadResult, UpgradeError> {
             let url = release.download_url.as_str();
             let archive_bytes = ureq::Agent::new_with_defaults()
                 .get(url)

--- a/rusty-stack/src/orchestrator/planner.rs
+++ b/rusty-stack/src/orchestrator/planner.rs
@@ -478,9 +478,7 @@ impl UpdatePlanner {
             .to_string();
 
         let visible = classification.is_visible();
-        let selected = classification.is_preselected()
-            && (matches!(classification, UpdateClassification::Safe)
-                || current_version != component.version);
+        let selected = classification.is_preselected() && current_version != component.version;
         let isolation_safe = matches!(classification, UpdateClassification::Safe);
 
         let classification_reason = self.classification_reason(

--- a/rusty-stack/src/orchestrator/planner.rs
+++ b/rusty-stack/src/orchestrator/planner.rs
@@ -288,7 +288,9 @@ impl UpdatePlanner {
         let planned_rocm_version = manifest
             .components
             .iter()
-            .find(|c| c.id == "rocm" && (target_set.contains("rocm") || required_deps.contains("rocm")))
+            .find(|c| {
+                c.id == "rocm" && (target_set.contains("rocm") || required_deps.contains("rocm"))
+            })
             .map(|c| c.version.as_str());
 
         let mut items = Vec::new();
@@ -304,13 +306,12 @@ impl UpdatePlanner {
             }
 
             // Classify the update
-            let classification =
-                self.classify_update(
-                    component,
-                    context,
-                    rocm_available_or_planned,
-                    planned_rocm_version,
-                );
+            let classification = self.classify_update(
+                component,
+                context,
+                rocm_available_or_planned,
+                planned_rocm_version,
+            );
 
             // If blocked, handle differently
             if classification == UpdateClassification::Blocked {
@@ -318,13 +319,12 @@ impl UpdatePlanner {
                 if target_set.contains(component.id.as_str())
                     || required_deps.contains(component.id.as_str())
                 {
-                        let reason =
-                        self.block_reason(
-                            component,
-                            context,
-                            rocm_available_or_planned,
-                            planned_rocm_version,
-                        );
+                    let reason = self.block_reason(
+                        component,
+                        context,
+                        rocm_available_or_planned,
+                        planned_rocm_version,
+                    );
                     return Err(PlannerError::ComponentBlocked {
                         component_id: component.id.clone(),
                         reason,
@@ -478,7 +478,9 @@ impl UpdatePlanner {
             .to_string();
 
         let visible = classification.is_visible();
-        let selected = classification.is_preselected() && current_version != component.version;
+        let selected = classification.is_preselected()
+            && (matches!(classification, UpdateClassification::Safe)
+                || current_version != component.version);
         let isolation_safe = matches!(classification, UpdateClassification::Safe);
 
         let classification_reason = self.classification_reason(
@@ -1566,7 +1568,11 @@ mod tests {
 
         let items = planner().build_plan(&manifest, &context, &options).unwrap();
 
-        assert_eq!(items.len(), 2, "Targeted component and dependencies are in scope");
+        assert_eq!(
+            items.len(),
+            2,
+            "Targeted component and dependencies are in scope"
+        );
 
         let triton = items
             .iter()
@@ -1619,7 +1625,10 @@ mod tests {
         };
 
         let items = planner().build_plan(&manifest, &context, &options).unwrap();
-        let ids: HashSet<_> = items.iter().map(|i| i.plan_item.component_id.as_str()).collect();
+        let ids: HashSet<_> = items
+            .iter()
+            .map(|i| i.plan_item.component_id.as_str())
+            .collect();
         assert!(ids.contains("rocm"));
         assert!(ids.contains("pytorch"));
     }
@@ -1642,7 +1651,10 @@ mod tests {
         };
 
         let items = planner().build_plan(&manifest, &context, &options).unwrap();
-        let ids: HashSet<_> = items.iter().map(|i| i.plan_item.component_id.as_str()).collect();
+        let ids: HashSet<_> = items
+            .iter()
+            .map(|i| i.plan_item.component_id.as_str())
+            .collect();
         assert!(ids.contains("custom-runtime"));
         assert!(ids.contains("rocm"));
         assert!(ids.contains("mpi4py"));
@@ -1665,7 +1677,10 @@ mod tests {
         };
 
         let items = planner().build_plan(&manifest, &context, &options).unwrap();
-        let ids: HashSet<_> = items.iter().map(|i| i.plan_item.component_id.as_str()).collect();
+        let ids: HashSet<_> = items
+            .iter()
+            .map(|i| i.plan_item.component_id.as_str())
+            .collect();
         assert!(ids.contains("rocm"));
         assert!(ids.contains("llama-cpp"));
     }

--- a/rusty-stack/tests/migration_wave1.rs
+++ b/rusty-stack/tests/migration_wave1.rs
@@ -341,8 +341,8 @@ fn test_integration_selection_plan_produces_ordered_list_with_defaults() {
     // Plan must have all 5 items
     assert_eq!(plan.len(), 5, "plan must include all 5 components");
 
-    // Same-version reinstalls are Safe → preselected
-    // New install (flash-attn) is Candidate → not preselected
+    // Same-version Reinstalls → Safe, but NOT preselected (nothing to install)
+    // New install (flash-attn) → Candidate, not preselected
     for item in &plan {
         if item.plan_item.component_id == "flash-attn" {
             assert_eq!(
@@ -360,7 +360,10 @@ fn test_integration_selection_plan_produces_ordered_list_with_defaults() {
                 UpdateClassification::Safe,
                 "validated same-version reinstall must be Safe"
             );
-            assert!(item.selected, "safe update must be preselected");
+            assert!(
+                !item.selected,
+                "same-version safe reinstall must not be preselected (nothing to install)"
+            );
         }
     }
 }

--- a/rusty-stack/tests/rusty_cli.rs
+++ b/rusty-stack/tests/rusty_cli.rs
@@ -174,6 +174,7 @@ fn test_rusty_upgrade_dry_run_reports_current_version() {
         .unwrap()
         .args(["upgrade", "--dry-run"])
         .assert()
+        .success()
         .get_output()
         .clone();
 

--- a/rusty-stack/tests/rusty_cli.rs
+++ b/rusty-stack/tests/rusty_cli.rs
@@ -173,14 +173,16 @@ fn test_rusty_upgrade_dry_run_reports_current_version() {
     let output = Command::cargo_bin(BIN)
         .unwrap()
         .args(["upgrade", "--dry-run"])
-        .assert()
-        .success()
-        .get_output()
-        .clone();
+        .output()
+        .expect("failed to execute rusty upgrade --dry-run");
 
     let stdout = String::from_utf8_lossy(&output.stdout);
     assert!(
         stdout.contains("Current version:"),
         "expected current-version output in dry run, got: {stdout}"
+    );
+    assert!(
+        stdout.contains("Schema version:"),
+        "expected schema-version output in dry run, got: {stdout}"
     );
 }

--- a/rusty-stack/tests/rusty_cli.rs
+++ b/rusty-stack/tests/rusty_cli.rs
@@ -164,12 +164,22 @@ fn test_rusty_update_scan_only_json() {
     let _: serde_json::Value = serde_json::from_str(&stdout).expect("Output should be valid JSON");
 }
 
+// ===========================================================================
+// Upgrade subcommand dry-run
+// ===========================================================================
+
 #[test]
-fn test_rusty_upgrade_dry_run() {
-    Command::cargo_bin(BIN)
+fn test_rusty_upgrade_dry_run_reports_current_version() {
+    let output = Command::cargo_bin(BIN)
         .unwrap()
         .args(["upgrade", "--dry-run"])
         .assert()
-        .success()
-        .stdout(predicate::str::contains("Current version:"));
+        .get_output()
+        .clone();
+
+    let stdout = String::from_utf8_lossy(&output.stdout);
+    assert!(
+        stdout.contains("Current version:"),
+        "expected current-version output in dry run, got: {stdout}"
+    );
 }

--- a/rusty_stack_wrapper/cli.py
+++ b/rusty_stack_wrapper/cli.py
@@ -52,7 +52,7 @@ def _install_from_crates_io() -> None:
     cargo = shutil.which("cargo")
     if not cargo:
         raise RuntimeError(
-            "cargo is required to install rusty from crates.io. "
+            "cargo is required to install rusty-stack from crates.io. "
             "Install Rust toolchain from https://rustup.rs/ and retry."
         )
 
@@ -70,7 +70,9 @@ def _install_from_crates_io() -> None:
     fallback_cmd = [cargo, "install", "--locked", CRATE_NAME]
     fallback = subprocess.run(fallback_cmd)
     if fallback.returncode != 0:
-        raise RuntimeError("failed to install rusty from crates.io via cargo install")
+        raise RuntimeError(
+            "failed to install rusty-stack from crates.io via cargo install"
+        )
 
 
 def _bin_version_matches(path: str) -> bool:

--- a/rusty_stack_wrapper/cli.py
+++ b/rusty_stack_wrapper/cli.py
@@ -8,7 +8,7 @@ import subprocess
 import sys
 from importlib import metadata
 
-CRATE_NAME = "rusty-stack"
+CRATE_NAME = "rusty"
 RUSTY_BIN = "rusty"
 INSTALLER_BIN = "rusty-stack"
 
@@ -52,7 +52,7 @@ def _install_from_crates_io() -> None:
     cargo = shutil.which("cargo")
     if not cargo:
         raise RuntimeError(
-            "cargo is required to install rusty-stack from crates.io. "
+            "cargo is required to install rusty from crates.io. "
             "Install Rust toolchain from https://rustup.rs/ and retry."
         )
 
@@ -70,7 +70,7 @@ def _install_from_crates_io() -> None:
     fallback_cmd = [cargo, "install", "--locked", CRATE_NAME]
     fallback = subprocess.run(fallback_cmd)
     if fallback.returncode != 0:
-        raise RuntimeError("failed to install rusty-stack from crates.io via cargo install")
+        raise RuntimeError("failed to install rusty from crates.io via cargo install")
 
 
 def _bin_version_matches(path: str) -> bool:

--- a/rusty_stack_wrapper/cli.py
+++ b/rusty_stack_wrapper/cli.py
@@ -8,7 +8,7 @@ import subprocess
 import sys
 from importlib import metadata
 
-CRATE_NAME = "rusty"
+CRATE_NAME = "rusty-stack"
 RUSTY_BIN = "rusty"
 INSTALLER_BIN = "rusty-stack"
 


### PR DESCRIPTION
## Summary

This PR adds the first crates.io publish path and changelog automation:

### What's new
- **crates.io publish**: `release.yml` now publishes the `rusty-stack` crate via `cargo publish --locked`
- **Changelog-on-merge**: New `update-changelog-on-merge.yml` workflow appends a changelog entry to `## [Unreleased]` for every PR merged to `main`
- **Release notes**: GitHub release body now includes `cargo install rusty-stack --locked` install instructions
- **Docs**: README, MIGRATION.md, and rusty_stack_guide.md updated to show crates.io as primary install path

### Package naming
- crates.io package: `rusty-stack` (the name `rusty` was already taken)
- crates.io install: `cargo install rusty-stack --locked`
- Binaries: `rusty-stack` (TUI installer) and `rusty` (CLI subcommand binary)

### Secrets required
- `CARGO_REGISTRY_TOKEN` — crates.io API token (must be configured in repo secrets before first publish)

### After merge
The `release.yml` workflow will trigger on the next push to `main` that changes `rusty-stack/Cargo.toml`, build binaries, create a draft GitHub Release, publish to crates.io, and publish the PyPI wrapper.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Primary install flow now uses crates.io: install via `cargo install rusty-stack --locked`.
  * PyPI package acts as a compatibility wrapper that installs/uses the matching crates.io binary.

* **Documentation**
  * Installation and migration docs updated to prioritize the crates.io installer and TUI.
  * ROCm channels updated (Stable: 7.2.3, Latest: 7.2.4).

* **Chores**
  * Automated changelog updates on PR merge.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->